### PR TITLE
Added MINIMAL_RECORDING_SIZE_IN_MB

### DIFF
--- a/Model.py
+++ b/Model.py
@@ -310,18 +310,29 @@ class Model:
 		
 		self._script_process.communicate()
 		
-		# Make the recording read- and writeable to the world
-		logging.debug('[Model._stop_recording] Making recording ' + self._flv + ' world read- and writeable')
-		os.chmod(TEMP_FOLDER + '/' + self._flv, 0666)
+		# Check if the recording is at least MINIMAL_RECORDING_SIZE_IN_MB big
+		if (os.path.getsize(TEMP_FOLDER + '/' + self._flv) >> 20) < MINIMAL_RECORDING_SIZE_IN_MB:
+			# recording is smaller than the minimal recording size, so delete file
 
-		# Moving the recording
-		logging.debug('[Model._stop_recording] Moving recording ' + self._flv + ' to ' + VIDEO_FOLDER)
-		os.rename(TEMP_FOLDER + '/' + self._flv, VIDEO_FOLDER + '/' + self._flv)
-		
+			# Deleting the recording, since it is too small
+			logging.debug('[Model._stop_recording] Deleting temp recording ' + self._flv + ' since it is too small')
+			os.remove(TEMP_FOLDER + '/' + self._flv)
+
+		else:
+			# recording is at least the minimal recording size, so move it to the saved folder
+			# Make the recording read- and writeable to the world
+			logging.debug('[Model._stop_recording] Making recording ' + self._flv + ' world read- and writeable')
+			os.chmod(TEMP_FOLDER + '/' + self._flv, 0666)
+
+			# Moving the recording
+			logging.debug('[Model._stop_recording] Moving recording ' + self._flv + ' to ' + VIDEO_FOLDER)
+			os.rename(TEMP_FOLDER + '/' + self._flv, VIDEO_FOLDER + '/' + self._flv)			
+			
+		# Clean up
 		self._flv = None
 		self._script_process = None
 		self._pid = -1
-#		os.kill(self._pid, signal.SIGTERM) # or signal.SIGKILL
+	#		os.kill(self._pid, signal.SIGTERM) # or signal.SIGKILL
 		logging.debug('[Model._stop_recording] Stopped recording: ' + self._id+ ' with pid ' + str(self._pid))
 		
 	def destroy(self):

--- a/config.conf
+++ b/config.conf
@@ -13,8 +13,9 @@ WANTED_FILE = wanted.txt
 [delays]
 DELAY = 45
 [version]
-VERSION = 7.3
+VERSION = 7.4
 [debug]
 DEBUGGING = False
 [advanced]
 RTMPDUMP = /usr/local/bin/rtmpdump
+MINIMAL_RECORDING_SIZE_IN_MB = 10

--- a/config.py
+++ b/config.py
@@ -117,7 +117,7 @@ VERSION = Config_file('version','VERSION')
 RTMPDUMP = Config_file('advanced','RTMPDUMP')
 # Enable storing html to debug.log file + set logging level
 DEBUGGING = ast.literal_eval(Config_file('debug','DEBUGGING'))
-
+MINIMAL_RECORDING_SIZE_IN_MB = int(float(Config_file('advanced','MINIMAL_RECORDING_SIZE_IN_MB')))
 # Constants
 REC_START = 'R+'
 REC_STOP = 'R-'


### PR DESCRIPTION
By setting a minimal value for each recording, any temp recording smaller than that size will be deleted.
